### PR TITLE
Add new option 'restart_increment_after'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,15 @@ plugins:
         exclude:
           - index.md
           - another_page.md
+        restart_increment_after:
+          - second_section.md
 ```
 
 - **`toc_depth`** (default `0`): Up to which level the table of contents should be enumerated as well. Default is 0, which means the TOC is not enumerated at all. Max is 6 (showing all enumeration)
 - **`strict`** (default `true`): Raise errors instead of warnings when first heading on a page is not a level one heading (single `#`) and your MkDocs theme has not inserted the page title as a heading 1 for you. Note that in `strict: false` mode the heading numbers might be incorrect between pages and before and after a level 1 heading.
 - **`increment_across_pages`** (default `true`): Increment the chapter number for each new page (in the order they appear in the navigation). If disabled, each page will start from 1.
 - **`exclude`** (default *not specified*): Specify a list of page source paths (one per line) that should not have enumeration (excluded from processing by this plugin). This can be useful for example to remove enumeration from the front page. The source path of a page is relative to your `docs/` folder. You can also use [globs](https://docs.python.org/3/library/glob.html) instead of source paths. For example, to exclude `docs/subfolder/page.md` specify in your `mkdocs.yml` a line under `exclude:` with `- subfolder/page.md`
+- **`restart_increment_after`** (default *not specified*): Specify a list of page source paths (one per line) where enumeration should be restarted. This can be useful if you have multiple reports or tutorials in one mkdocs site. Paths behave as with `exclude` (can use globs).
 
 ## Contributing
 

--- a/mkdocs_enumerate_headings_plugin/plugin.py
+++ b/mkdocs_enumerate_headings_plugin/plugin.py
@@ -19,6 +19,7 @@ class EnumerateHeadingsPlugin(BasePlugin):
         ("strict", config_options.Type(bool, default=True)),
         ("toc_depth", config_options.Type(int, default=0)),
         ("increment_across_pages", config_options.Type(bool, default=True)),
+        ("restart_increment_after", config_options.Type(list, default=[])),
         ("exclude", config_options.Type(list, default=[])),
     )
 
@@ -115,6 +116,11 @@ class EnumerateHeadingsPlugin(BasePlugin):
 
             # Optionally do not increment counter across pages.
             if self.config.get('increment_across_pages') is False:
+                chapter_counter = 0
+
+            # Optionally reset the counter for this page
+            restarting_pages = self.config.get("restart_increment_after", [])
+            if exclude(page.file.src_path, restarting_pages):
                 chapter_counter = 0
 
             # Some markdown files could be used multiple times in the same navigation


### PR DESCRIPTION
After writing timvink/mkdocs-enumerate-headings-plugin#32 I couldn't resist having a quick look at the code to see where this might go. It looked pretty easy so I had a play and it pretty much worked on my first go. So here's a pull request! 😁 

Adds a new config option `restart_increment_after` which hijacks the `exclude()` function and resets the counter to `0` if the current page matches anything.