### PR TITLE
Add include to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ plugins:
         toc_depth: 0
         strict: true
         increment_across_pages: true
+        include:
+          - "*"
         exclude:
           - index.md
           - another_page.md
@@ -86,6 +88,7 @@ plugins:
 - **`toc_depth`** (default `0`): Up to which level the table of contents should be enumerated as well. Default is 0, which means the TOC is not enumerated at all. Max is 6 (showing all enumeration)
 - **`strict`** (default `true`): Raise errors instead of warnings when first heading on a page is not a level one heading (single `#`) and your MkDocs theme has not inserted the page title as a heading 1 for you. Note that in `strict: false` mode the heading numbers might be incorrect between pages and before and after a level 1 heading.
 - **`increment_across_pages`** (default `true`): Increment the chapter number for each new page (in the order they appear in the navigation). If disabled, each page will start from 1.
+- **`include`** (default *`["*"]`*): Specify a list of page source paths (one per line) that should have enumeration (included in processing by this plugin). This can be useful for example to include enumeration on only one directory. The source path of a page is relative to your `docs/` folder. You can also use [globs](https://docs.python.org/3/library/glob.html) instead of source paths. For example, to include `docs/subfolder/page.md` specify in your `mkdocs.yml` a line under `include:` with `- subfolder/page.md`
 - **`exclude`** (default *not specified*): Specify a list of page source paths (one per line) that should not have enumeration (excluded from processing by this plugin). This can be useful for example to remove enumeration from the front page. The source path of a page is relative to your `docs/` folder. You can also use [globs](https://docs.python.org/3/library/glob.html) instead of source paths. For example, to exclude `docs/subfolder/page.md` specify in your `mkdocs.yml` a line under `exclude:` with `- subfolder/page.md`
 - **`restart_increment_after`** (default *not specified*): Specify a list of page source paths (one per line) where enumeration should be restarted. This can be useful if you have multiple reports or tutorials in one mkdocs site. Paths behave as with `exclude` (can use globs).
 

--- a/mkdocs_enumerate_headings_plugin/exclude.py
+++ b/mkdocs_enumerate_headings_plugin/exclude.py
@@ -18,7 +18,7 @@ def include(src_path: str, globs: List[str]) -> bool:
     Returns:
         (bool): whether src_path should be excluded
     """
-    return matches_fixed_path(src_path, globs)
+    return matches_nix_path(src_path, globs)
 
 
 def exclude(src_path: str, globs: List[str]) -> bool:
@@ -31,10 +31,10 @@ def exclude(src_path: str, globs: List[str]) -> bool:
     Returns:
         (bool): whether src_path should be excluded
     """
-    return matches_fixed_path(src_path, globs)
+    return matches_nix_path(src_path, globs)
 
 
-def matches_fixed_path(src_path: str, globs: List[str]) -> bool:
+def matches_nix_path(src_path: str, globs: List[str]) -> bool:
     """
     Determines if a src_path matches one of the provided glob patterns.
     Supports globs (e.g. folder/* or *.md).

--- a/mkdocs_enumerate_headings_plugin/exclude.py
+++ b/mkdocs_enumerate_headings_plugin/exclude.py
@@ -7,37 +7,59 @@ import fnmatch
 from typing import List
 
 
-def exclude(src_path: str, globs: List[str]) -> bool:
+def include(src_path: str, globs: List[str]) -> bool:
     """
-    Determine if a src_path should be excluded.
+    Determine if a src_path should be included.
     Supports globs (e.g. folder/* or *.md).
-    Credits: code inspired by / adapted from
-    https://github.com/apenwarr/mkdocs-exclude/blob/master/mkdocs_exclude/plugin.py
+
     Args:
         src_path (src): Path of file
-        globs (list): list of globs
+        globs (list): list of globs of file paths to include
     Returns:
         (bool): whether src_path should be excluded
     """
+    return matches_fixed_path(src_path, globs)
+
+
+def exclude(src_path: str, globs: List[str]) -> bool:
+    """
+    Determine if a src_path should be excluded.
+
+    Args:
+        src_path (src): Path of file
+        globs (list): list of globs of file paths to include
+    Returns:
+        (bool): whether src_path should be excluded
+    """
+    return matches_fixed_path(src_path, globs)
+
+
+def matches_fixed_path(src_path: str, globs: List[str]) -> bool:
+    """
+    Determines if a src_path matches one of the provided glob patterns.
+    Supports globs (e.g. folder/* or *.md).
+    Credits: code inspired by / adapted from
+    https://github.com/apenwarr/mkdocs-exclude/blob/master/mkdocs_exclude/plugin.py
+
+    Args:
+        src_path (src): Path of file
+        globs (list): list of globs of file paths to include
+    Returns:
+        (bool): whether src_path should be excluded
+    """
+
     assert isinstance(src_path, str)
     assert isinstance(globs, list)
 
-    for g in globs:
-        if fnmatch.fnmatchcase(src_path, g):
-            return True
+    # Windows reports filenames as eg.  a\\b\\c instead of a/b/c.
+    # To make the same globs/regexes match filenames on Windows and
+    # other OSes, let's try matching against converted filenames.
+    # On the other hand, Unix actually allows filenames to contain
+    # literal \\ characters (although it is rare), so we won't
+    # always convert them.  We only convert if os.sep reports
+    # something unusual.  Conversely, some future mkdocs might
+    # report Windows filenames using / separators regardless of
+    # os.sep, so we *always* test with / above.
+    fixed_path = src_path.replace(os.sep, "/")
 
-        # Windows reports filenames as eg.  a\\b\\c instead of a/b/c.
-        # To make the same globs/regexes match filenames on Windows and
-        # other OSes, let's try matching against converted filenames.
-        # On the other hand, Unix actually allows filenames to contain
-        # literal \\ characters (although it is rare), so we won't
-        # always convert them.  We only convert if os.sep reports
-        # something unusual.  Conversely, some future mkdocs might
-        # report Windows filenames using / separators regardless of
-        # os.sep, so we *always* test with / above.
-        if os.sep != "/":
-            src_path_fix = src_path.replace(os.sep, "/")
-            if fnmatch.fnmatchcase(src_path_fix, g):
-                return True
-
-    return False
+    return any(fnmatch.fnmatch(fixed_path, glob) for glob in globs)

--- a/mkdocs_enumerate_headings_plugin/plugin.py
+++ b/mkdocs_enumerate_headings_plugin/plugin.py
@@ -8,7 +8,7 @@ from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
 from mkdocs.exceptions import ConfigurationError
 from mkdocs_enumerate_headings_plugin.html_page import HTMLPage
-from mkdocs_enumerate_headings_plugin.exclude import exclude
+from mkdocs_enumerate_headings_plugin.exclude import exclude, include
 from bs4 import BeautifulSoup
 
 logger = logging.getLogger("mkdocs.plugins")
@@ -95,10 +95,13 @@ class EnumerateHeadingsPlugin(BasePlugin):
         markdown_files_processed = {}
 
         for page in nav.pages:
-
+            # Include pages specified in config
+            included_pages = self.config.get("include", ["*"])
             # Exclude pages specified in config
             excluded_pages = self.config.get("exclude", [])
-            if exclude(page.file.src_path, excluded_pages):
+            if not include(page.file.src_path, included_pages) or exclude(
+                page.file.src_path, excluded_pages
+            ):
                 continue
 
             # We need to build the pages in order to find out

--- a/mkdocs_enumerate_headings_plugin/plugin.py
+++ b/mkdocs_enumerate_headings_plugin/plugin.py
@@ -20,6 +20,7 @@ class EnumerateHeadingsPlugin(BasePlugin):
         ("toc_depth", config_options.Type(int, default=0)),
         ("increment_across_pages", config_options.Type(bool, default=True)),
         ("restart_increment_after", config_options.Type(list, default=[])),
+        ("include", config_options.Type(list, default=["*"])),
         ("exclude", config_options.Type(list, default=[])),
     )
 


### PR DESCRIPTION
Adds the option to include path globs, useful when you just want to enumerate one directory. Should maybe rename `exclude.py` to something else