### PR TITLE
enumerate nav links

### DIFF
--- a/mkdocs_enumerate_headings_plugin/plugin.py
+++ b/mkdocs_enumerate_headings_plugin/plugin.py
@@ -138,6 +138,7 @@ class EnumerateHeadingsPlugin(BasePlugin):
                 chapter = markdown_files_processed[page.file.abs_src_path]
 
             page.chapter = chapter
+            page.title = f"{chapter}. {page.title}"
 
     def on_post_page(self, output, page, config, **kwargs):
         """


### PR DESCRIPTION
Since chapter numbers are added to `h1` titles it seems logical to me that you would want enumeration in the site navigation, too (which is distinct from the TOC). See [the plugin demo gif](https://github.com/timvink/mkdocs-enumerate-headings-plugin/blob/master/demo_screencast.gif), where chapter titles occur unnumbered in the navigation, and numbered in the body.

(`exclude` works as expected)