### PR TITLE
Make sure "tests" is not installed as a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    packages=find_packages(),
+    packages=["mkdocs_enumerate_headings_plugin"],
     entry_points={
         "mkdocs.plugins": [
             "enumerate-headings=mkdocs_enumerate_headings_plugin.plugin:EnumerateHeadingsPlugin",


### PR DESCRIPTION
Currently, our tests folder is conflicting with the "tests" site-package, which is installed by this plugin.