### PR TITLE
chore: switch mkdocs dependency to mkdocs-ng

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="vinktim@gmail.com",
     license="MIT",
     python_requires=">=3.7",
-    install_requires=["mkdocs>=1.0.4", "beautifulsoup4>=4.9.0"],
+    install_requires=["mkdocs-ng", "beautifulsoup4>=4.9.0"],
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",


### PR DESCRIPTION
Hi, this is a small PR to suggest switching the `mkdocs` dependency to `mkdocs-ng`.

The `mkdocs` package on PyPI is currently unmaintained — see [Is MkDocs still maintained?](https://github.com/mkdocs/mkdocs/discussions/4010) and [The Slow Collapse of MkDocs](https://fpgmaas.com/blog/collapse-of-mkdocs/) for context.

[`mkdocs-ng`](https://pypi.org/project/mkdocs-ng/) is a community-maintained fork that:
- Keeps the same `mkdocs` CLI — no changes for end users
- Adds Python 3.13 / 3.14 support
- Includes bug fixes and active development
- One-line drop-in replacement

```diff
- mkdocs
+ mkdocs-ng
```

No obligation — just sharing in case it's helpful. Thanks!